### PR TITLE
Make the Onboarding Screen more reactive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "BraveAlertApp",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "iphone6": "react-native run-ios --simulator=\"iPhone 6\"",
+    "iphone8": "react-native run-ios --simulator=\"iPhone 8 (14.4)\"",
     "start": "react-native start",
     "test": "NODE_ENV=test jest --no-cache",
     "lint": "eslint --ext .js,.jsx .",

--- a/src/components/Cards/Cards.jsx
+++ b/src/components/Cards/Cards.jsx
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-around',
     height: 14,
-    marginTop: 25,
+    marginTop: 10,
   },
 })
 

--- a/src/components/Cards/ContactBraveBoxesCard.jsx
+++ b/src/components/Cards/ContactBraveBoxesCard.jsx
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
     fontFamily: 'Roboto-Regular',
     fontSize: 14,
     textAlign: 'center',
-    marginBottom: 25,
+    marginBottom: 15,
   },
 })
 

--- a/src/screens/OnboardingScreen.jsx
+++ b/src/screens/OnboardingScreen.jsx
@@ -25,7 +25,6 @@ const styles = StyleSheet.create({
     fontSize: 20,
     textAlign: 'center',
     letterSpacing: 6,
-    marginBottom: 25,
   },
   braveText: {
     color: colors.primaryMedium,
@@ -33,25 +32,30 @@ const styles = StyleSheet.create({
     fontSize: 30,
     textAlign: 'center',
     letterSpacing: 7,
-    marginBottom: 10,
+    marginBottom: 6,
   },
   button: {
-    marginBottom: 41,
-  },
-  cards: {
-    marginBottom: 25,
+    flexGrow: 1,
+    justifyContent: 'center',
   },
   container: {
     backgroundColor: colors.greyscaleLightest,
-    height: '100%',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  modalContainer: {
+    flex: 0, // Do not take up any vertical space on the non-modal part of the screen
+  },
+  welcomeContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
   },
   welcomeText: {
     color: colors.greyscaleDark,
     fontFamily: 'Roboto-Regular',
     fontSize: 16,
     textAlign: 'center',
-    marginTop: 60,
-    marginBottom: 20,
+    marginBottom: 6,
   },
 })
 
@@ -96,11 +100,13 @@ function OnboardingScreen() {
     <>
       <StatusBar barStyle="dark-content" />
       <SafeAreaView style={styles.container}>
-        <Text style={styles.welcomeText}>Welcome to</Text>
-        <Text style={styles.braveText}>BRAVE</Text>
-        <Text style={styles.alertText}>ALERT</Text>
+        <View style={styles.welcomeContainer}>
+          <Text style={styles.welcomeText}>Welcome to</Text>
+          <Text style={styles.braveText}>BRAVE</Text>
+          <Text style={styles.alertText}>ALERT</Text>
+        </View>
 
-        <View style={styles.cards}>
+        <View>
           <Cards>
             <ImageCard icon={faRunning} text="First time using Brave Alert? Swipe to learn more, or connect to the app right away." />
             <ImageCard icon={faExclamationCircle} text="Brave Alert will notify you if someone needs support." />
@@ -125,11 +131,13 @@ function OnboardingScreen() {
         </View>
       </SafeAreaView>
 
-      <ModalContainer isModalVisible={numVisibleModals > 0}>
-        <ModalView backgroundColor={colors.greyscaleLightest} hasCloseButton setNumVisibleModals={setNumVisibleModals}>
-          <VerificationCodeModal verificationCode={`${verificationCode}`} setNumVisibleModals={setNumVisibleModals} />
-        </ModalView>
-      </ModalContainer>
+      <View style={styles.modalContainer}>
+        <ModalContainer isModalVisible={numVisibleModals > 0}>
+          <ModalView backgroundColor={colors.greyscaleLightest} hasCloseButton setNumVisibleModals={setNumVisibleModals}>
+            <VerificationCodeModal verificationCode={`${verificationCode}`} setNumVisibleModals={setNumVisibleModals} />
+          </ModalView>
+        </ModalContainer>
+      </View>
     </>
   )
 }


### PR DESCRIPTION
- There were a few screen sizes, including Dave's iPhone,
  where the "Connect to App" button was pushed off the
  bottom of the screen.
- Reduced the spacing between the items on this page
- Used Flexbox to make the static parts of the screen
  evenly distribute the unused space between them and
  center their contents

Test plan:
- :heavy_check_mark:All elements on the page are completely visible and usable on the following devices:
   - :heavy_check_mark: My Android emulator
   - :heavy_check_mark: My iPhone 6 simulator
   - :heavy_check_mark: My iPhone 8 simulator
   - :heavy_check_mark: v1.0.70 on my Huawei (Android 8.0.1)
   - :heavy_check_mark: v1.0.70 on Dave's iPhone8 (iOS 14.6)
- :heavy_check_mark: Tests all passed locally
- :heavy_check_mark: Linting passed locally
- ✔️  Travis passes on #13 (the exact same PR but without running `npm audit`)