### PR TITLE
Alert history screen (only buttons works) (CU-hjwfx2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ the code was deployed.
 - Roboto font (CU-hjwctk).
 - Contact screen (CU-hjwg2y).
 - audit-ci for security audit of dependencies on Travis.
+- Historic Alert screen (CU-hjwfx2).
 
 ### Removed
 

--- a/src/components/HistoricAlert/HistoricAlert.jsx
+++ b/src/components/HistoricAlert/HistoricAlert.jsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
 })
 
 function HistoricAlert(props) {
-  const { alertType, roomName, alertTime, category, responseTime, numButtonPresses } = props
+  const { alertType, deviceName, alertTime, category, responseTime, numButtonPresses } = props
   const [isExpanded, setIsExpanded] = useState(false)
   const [expandedHeight] = useState(new Animated.Value(0))
   const [expandedOpacity] = useState(new Animated.Value(0))
@@ -115,7 +115,7 @@ function HistoricAlert(props) {
               <Text style={[styles.textStartTime, { color }]}>{alertTime}</Text>
             </View>
             <View style={styles.room}>
-              <Text style={styles.textRoom}>{roomName}</Text>
+              <Text style={styles.textRoom}>{deviceName}</Text>
               <FontAwesomeIcon icon={isExpanded ? faChevronUp : faChevronDown} size={20} />
             </View>
           </View>

--- a/src/components/PageHeader/PageHeader.jsx
+++ b/src/components/PageHeader/PageHeader.jsx
@@ -8,12 +8,13 @@ import colors from '../../resources/colors'
 const styles = StyleSheet.create({
   headerContainer: {
     alignItems: 'center',
+    marginBottom: 40,
+    marginTop: 30,
   },
   title: {
     color: colors.primaryDark,
     fontFamily: 'Roboto-Bold',
     fontSize: 16,
-    marginBottom: 40,
     textAlign: 'center',
   },
 })

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,3 +13,14 @@ export function formatTimeString(utcTimestamp) {
   const ampm = twentyFourHours < 12 ? 'AM' : 'PM'
   return `${hours}:${timestamp.getMinutes().toString().padStart(2, '0')} ${ampm}`
 }
+
+/**
+ * Returns true if the two given timestamps in UTC have the same year, month, and date
+ * in the device's local timezone. Returns false otherwise.
+ */
+export function isSameYearMonthDate(utcTimestamp1, utcTimestamp2) {
+  const date1 = new Date(utcTimestamp1)
+  const date2 = new Date(utcTimestamp2)
+
+  return date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth() && date1.getDate() === date2.getDate()
+}

--- a/src/hooks/safeHandler.js
+++ b/src/hooks/safeHandler.js
@@ -32,7 +32,7 @@ export function useSafeHandler() {
   }
 
   async function fire(fn, options = {}) {
-    const { rollbackScreen = SCREEN.EXAMPLE } = options
+    const { rollbackScreen = SCREEN.ONBOARDING } = options
 
     function handleError(error) {
       safeReportError(error)

--- a/src/screens/ContactScreen.jsx
+++ b/src/screens/ContactScreen.jsx
@@ -121,7 +121,7 @@ function ContactScreen() {
     }
 
     fireFormSubmission(handle, {
-      rollbackScreen: SCREEN.CONTACT,
+      rollbackScreen: SCREEN.HOME,
     })
   }
 

--- a/src/screens/ContactScreen.jsx
+++ b/src/screens/ContactScreen.jsx
@@ -43,7 +43,6 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     flexWrap: 'nowrap',
     backgroundColor: colors.greyscaleLighter,
-    marginTop: 40,
     marginHorizontal: 21,
   },
   radioButtonGroupContainer: {

--- a/src/screens/SplashScreen.jsx
+++ b/src/screens/SplashScreen.jsx
@@ -1,6 +1,6 @@
 // Third-party dependencies
 import React, { useEffect } from 'react'
-import { SafeAreaView, StyleSheet, StatusBar, Text } from 'react-native'
+import { ActivityIndicator, SafeAreaView, StyleSheet, StatusBar, Text } from 'react-native'
 import { useNavigation } from '@react-navigation/native'
 import { useDispatch } from 'react-redux'
 import { BUTTONS_BASE_URL, SENSOR_BASE_URL } from '@env'
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
     textAlign: 'center',
     letterSpacing: 6,
-    marginBottom: 100,
+    marginBottom: 80,
   },
   braveText: {
     color: colors.greyscaleLightest,
@@ -37,13 +37,6 @@ const styles = StyleSheet.create({
     alignContent: 'center',
     justifyContent: 'center',
     backgroundColor: colors.primaryMedium,
-  },
-  loadingText: {
-    fontFamily: 'Roboto-Regular',
-    fontSize: 20,
-    color: colors.greyscaleLightest,
-    textAlign: 'center',
-    textAlignVertical: 'center',
   },
 })
 
@@ -88,7 +81,7 @@ function SplashScreen() {
       <SafeAreaView style={styles.container}>
         <Text style={styles.braveText}>BRAVE</Text>
         <Text style={styles.alertText}>ALERT</Text>
-        <Text style={styles.loadingText}>Loading...</Text>
+        <ActivityIndicator size="large" color={colors.greyscaleLighter} />
       </SafeAreaView>
     </>
   )

--- a/src/services/AlertApiService.js
+++ b/src/services/AlertApiService.js
@@ -29,6 +29,21 @@ async function getLocation(baseUrl) {
   })
 }
 
+async function getHistoricAlerts(baseUrl, maxHistoricAlerts) {
+  return get({
+    base: baseUrl,
+    uri: `/alert/historicAlerts`,
+    params: {
+      maxHistoricAlerts,
+    },
+    headers: {
+      'X-API-KEY': getApiKey(),
+      'Content-Type': 'application/json',
+    },
+    transformResponse: JSON.parse,
+  })
+}
+
 async function testRequest(baseUrl) {
   return post({
     base: baseUrl,
@@ -52,6 +67,7 @@ async function fakeEndpointRequest(baseUrl) {
 export default {
   designateDeviceRequest,
   fakeEndpointRequest,
+  getHistoricAlerts,
   getLocation,
   testRequest,
 }


### PR DESCRIPTION
- Alert History Screen is now populated with the real values for any associated  Buttons system.
- It currently doesn't get any real values from Sensors because work on the backend code is currently blocked.
- Used a spinner instead of the text "Loading..." on the SplashScreen because research shows that people prefer when something is moving while they wait. It's reassuring to know that *something* is going on.
- Added a timeout to API requests from the FetchService. For awhile I was hitting an API that didn't timeout until 60 seconds, this was way too long to wait. So now this will timeout at 25 seconds. I hope that clients' Internet is good enough that this won't be an issue.
- Changed default rollbackScreens to ONBOARDING. The rollback screen must be accessible from the current navigation. Since the TabNavigation values are not accessible from the StackNavigation, the default is best to be one in the StackNavigation

I'd like to merge this even though it's not done yet because we are starting to work on other branches and it would be easier if this were in there. There is another branch `td-alert-history-screen` which has the changes that will go in once the Sensors backend is ready.

Testing:
- ✔️  Display Buttons Alerts with the following properties:
   - ✔️  Different Alert Reasons (BUTTONS_URGENT, BUTTONS_NOT_URGENT
   - ✔️  Different Incident Categories (none, Accidental, Safer User, etc)
   - ✔️  Difference start datetimes
   - ✔️  Different number of button presses
   - ✔️  Different responded at datetimes (same day as the start datetime, a later day than the start datetime
- ✔️  Display Historic Alert list with the following properties:
   - ✔️  Different start dates (a day with only one historic alert, a day with multiple historic alerts, multiple days with historic alerts)
   - ✔️  Different numbers of alerts (0, less than the limit to display, more than the limit to display   
- ✔️  Loading spinner on SplashScreen
- ✔️  Loading spinner each time arrive on Historic Alert Screen
- ✔️  Timeout when hitting an API that takes a really long time to return