### PR TITLE
added notifications counting for Sensors (CU-hjwcwk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ the code was deployed.
 - audit-ci for security audit of dependencies on Travis.
 - Historic Alert screen (CU-hjwfx2).
 - Push Notifications (CU-hjwjfj, CU-10xfkhr).
+- new notifications counting (CU-hjwcwk).
 
 ### Removed
 

--- a/src/screens/HomeScreen.jsx
+++ b/src/screens/HomeScreen.jsx
@@ -61,13 +61,12 @@ function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       async function handle() {
-        // TODO: enable sensors request
         const promises = [
           AlertApiService.getNewNotificationsCountRequest(BUTTONS_BASE_URL),
-          // AlertApiService.getNewNotificationsCountRequest(SENSOR_BASE_URL),
+          AlertApiService.getNewNotificationsCountRequest(SENSOR_BASE_URL),
         ]
-        const [buttonsResult /* , sensorsResult */] = await Promise.all(promises)
-        dispatch(setNewNotificationsCount(buttonsResult /* + sensorsResult */))
+        const [buttonsResult, sensorsResult] = await Promise.all(promises)
+        dispatch(setNewNotificationsCount(buttonsResult + sensorsResult))
       }
 
       fireGetNewNotificationsCountRequest(handle, {


### PR DESCRIPTION
this pull request adds the connection to the Sensors backend when counting notifications.

testing notes:

- the automated tests passed on Travis when pushing the branch to Github
- I tested this on an Android emulator connected to the backend development environments for Buttons and Sensors. everything seems to work as expected.